### PR TITLE
feat: 支持基本的 Swagger 文档生成

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,7 @@ req := pkgName.Params.Func() // 另一个包下的变量下的函数
 c.JSONOK(req.Data)
 ```
 
-
+### TODO
+- [ ] 支持 GIN 的 Query / FormData 参数解析
+- [ ] 支持解析字段是否 Required (需要依赖注释解析)
+- [ ] 支持解析 Query / Form-Data 参数的类型/约束/描述 (需要依赖注释解析)

--- a/testdata/bff/pkg/shop/shop.go
+++ b/testdata/bff/pkg/shop/shop.go
@@ -24,11 +24,11 @@ type TeacherRes struct {
 }
 
 func GoodCreate(c *bffcore.Context) {
-	//var req GoodCreateReq
-	//if err := c.Bind(&req); err != nil {
-	//	c.JSONE(1, "error", nil)
-	//	return
-	//}
+	var req GoodCreateReq
+	if err := c.Bind(&req); err != nil {
+		c.JSONE(1, "error", nil)
+		return
+	}
 	////info, _ := invoker.Grpc.ListAllByUid(c.Request.Context(), &communityv1.ListAllByUidRequest{})
 	res := []TeacherRes{}
 	c.JSONOK(res, nil)


### PR DESCRIPTION
支持基本的 Swagger 文档生成

## TODO
- 支持 Query / Form-Data 参数 （ `c.Query()` `c.Form()` 等用法)
- 支持指定字段是否 required
- 支持指定 Query / Form-Data 参数的类型/约束/描述
