### PR TITLE
slice/array 类型 schema 解析; 支持配置自定义 Bind 函数; 支持 c.Bind() 解析为 form 参数

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,4 @@
 
 由于本工具是通过分析 AST 中的必要部分而不执行代码（类似于静态分析）的方式实现的，因此不能覆盖到任一种使用场景。如果你要在项目中使用本工具，您的代码必须必须要按照一定的约定编写，否则将不能生成完整的文档。虽然这给你的代码编写带来了一定的约束，但从另一个角度看，这也使得代码风格更加统一。
 
-本工具暂时只支持了有限的框架（现阶段只支持了 `egin` 的路由）。如果你需要将本项目进行扩展或应用于未支持的框架，本工具实现了插件机制，你可以编写自定义插件。
-
-## 插件 Plugin
-
-> TODO
-
-## 生命周期 Lifecycle
-1. Parsing Routes
-    1. Method
-    2. Path
-    3. Handler Name
-2. Parsing Handlers
-    1. Request Parameters (Query-Parameters/Path-Parameters/Body-Payload)
-    2. Response (Status-Code/Data-Type)
+本工具目前支持了 `gin` 框架的文档生成。如果你需要将本项目进行扩展或应用于未支持的框架，可以通过编写自定义插件的方式进行实现。

--- a/README.md
+++ b/README.md
@@ -1,9 +1,68 @@
-# ego-gen-api [WIP]
+# ego-gen [WIP]
 
-**本项目正在开发中，暂不能在实际场景中使用**
+`ego-gen-api` 通过分析 AST 解析出代码中的路由（方法/路径）和 Handler 函数（请求响应参数/响应状态码等）获取接口的信息，进而生成 Swagger 文档。
 
-`ego-gen-api` 通过分析 AST 解析出代码中的路由（方法/路径）和 Handler 函数获取接口的信息（请求响应参数/响应状态码等），进而生成 Swagger 文档。
-
-由于本工具是通过分析 AST 中的必要部分而不执行代码（类似于静态分析）的方式实现的，因此不能覆盖到任一种使用场景。如果你要在项目中使用本工具，您的代码必须必须要按照一定的约定编写，否则将不能生成完整的文档。虽然这给你的代码编写带来了一定的约束，但从另一个角度看，这也使得代码风格更加统一。
+由于本工具只分析 AST 中的关键部分（类似于静态分析）而不执行代码，因此并不能覆盖到任一种使用场景。如果你要在项目中使用本工具，必须要按照一定的约定编写代码，否则将不能生成完整的文档。虽然这给你的代码编写带来了一定的约束，但从另一个角度看，这也使得代码风格更加统一。
 
 本工具目前支持了 `gin` 框架的文档生成。如果你需要将本项目进行扩展或应用于未支持的框架，可以通过编写自定义插件的方式进行实现。
+
+## 安装 Install
+```shell
+go install github.com/gotomicro/ego-gen-api/cmd/egen@latest
+```
+
+## 如何使用 How to Use
+### 通过配置文件
+**egen.yaml**:
+```yaml
+output: docs
+plugin: gin
+dir: 'api' # 需要解析的代码根目录
+```
+> [完整的配置文件](#配置文件)
+
+在代码根目录下执行:
+```shell
+egen --config egn.yaml
+```
+
+### 通过命令行参数
+
+在代码根目录下执行:
+```shell
+egen --output docs --plugin gin --dir api
+```
+
+执行以上命令后，会在 `/docs` 目录下生成 `swagger.json` 文件。
+
+
+## 配置文件
+如下是完整的配置文件示例:
+```yaml
+output: docs # 输出文档的目录
+plugin: gin # 暂时只支持 gin
+dir: 'api' # 需要解析的代码目录
+
+# 可选. 请求/响应数据中依赖的类型对应的包
+depends:
+ - github.com/gotomicro/gotoant
+ - gorm.io/datatypes
+ - git.shimo.im/gopkg/mo-ego-component
+
+# 可选. 插件属性. 用于自定义请求响应的函数调用
+properties:
+  # 自定义请求参数绑定
+  request:
+    - type: '*github.com/clickvisual/clickvisual/api/pkg/component/core.Context'
+      method: 'Bind'
+      return:
+        data: 'args[0]' # 指定第一个函数参数为请求参数
+  # 自定义响应函数
+  response:
+    - type: '*github.com/clickvisual/clickvisual/api/pkg/component/core.Context'
+      method: 'JSONOK'
+      return:
+        contentType: 'application/json' # 指定响应的 content-type
+        data: 'args[0]' # 指定为第一个参数为接口响应参数
+        status: 200 # 指定为 200 状态码
+```

--- a/comment.go
+++ b/comment.go
@@ -79,6 +79,16 @@ func (c *Comment) Tags() []string {
 	return res
 }
 
+func (c *Comment) Ignore() bool {
+	for _, annot := range c.Annotations {
+		_, ok := annot.(*annotation.IgnoreAnnotation)
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
 func ParseComment(commentGroup *ast.CommentGroup) *Comment {
 	if commentGroup == nil {
 		return nil

--- a/context.go
+++ b/context.go
@@ -116,7 +116,7 @@ func (c *Context) ParseStatusCode(status ast.Expr) int {
 }
 
 func (c *Context) GetSchemaByExpr(expr ast.Expr, contentType string) *spec.Schema {
-	return NewSchemaBuilder(c, contentType).GetSchemaByExpr(expr, contentType)
+	return NewSchemaBuilder(c, contentType).ParseExpr(expr)
 }
 
 func (c *Context) FindHeadCommentOf(pos token.Pos) *ast.CommentGroup {

--- a/param_parser.go
+++ b/param_parser.go
@@ -1,0 +1,199 @@
+package analyzer
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/go-openapi/spec"
+	"github.com/gotomicro/ego-gen-api/tag"
+)
+
+type ParamParser struct {
+	ctx         *Context
+	contentType string
+}
+
+func NewParamParser(ctx *Context, contentType string) *ParamParser {
+	return &ParamParser{ctx: ctx, contentType: contentType}
+}
+
+// Parse 根据 ast.Expr 解析出 []*spec.Parameter
+func (p *ParamParser) Parse(expr ast.Expr) (params []*spec.Parameter) {
+	switch expr := expr.(type) {
+	case *ast.Ident:
+		return p.parseIdent(expr)
+	case *ast.StarExpr:
+		return p.Parse(expr.X)
+	case *ast.UnaryExpr:
+		return p.Parse(expr.X)
+	case *ast.SelectorExpr:
+		return p.Parse(expr.Sel)
+	}
+	return
+}
+
+func (p *ParamParser) parseIdent(expr *ast.Ident) (params []*spec.Parameter) {
+	t := p.ctx.Package().TypesInfo.TypeOf(expr)
+	if t == nil {
+		return
+	}
+
+	return p.parseType(t)
+}
+
+func (p *ParamParser) parseType(t types.Type) (params []*spec.Parameter) {
+	def := p.ctx.ParseType(t)
+	typeDef, ok := def.(*TypeDefinition)
+	if !ok {
+		return nil
+	}
+	structType, ok := typeDef.Spec.Type.(*ast.StructType)
+	if !ok {
+		return
+	}
+
+	params = NewParamParser(
+		p.ctx.WithPackage(typeDef.Pkg()).WithFile(typeDef.File()),
+		p.contentType,
+	).parseStructType(structType)
+	return
+}
+
+func (p *ParamParser) parseStructType(structType *ast.StructType) (params []*spec.Parameter) {
+	for _, field := range structType.Fields.List {
+		for _, name := range field.Names {
+			param := p.parseField(name, field)
+			params = append(params, param)
+		}
+	}
+	return
+}
+
+func (p *ParamParser) parseField(name *ast.Ident, field *ast.Field) (param *spec.Parameter) {
+	param = &spec.Parameter{}
+	param.Type, param.Format = p.typeOf(field.Type)
+
+	tagValues := tag.Parse(field.Tag.Value)
+	formName, ok := tagValues["form"]
+	if !ok {
+		formName = name.Name
+	}
+	param.Name = formName
+
+	// parse comments
+	comments := ParseComment(field.Doc)
+	if comments != nil {
+		param.Required = comments.Required()
+		param.Nullable = comments.Nullable()
+		param.Description = comments.Text
+	}
+
+	return
+}
+
+func (p *ParamParser) typeOf(expr ast.Expr) (string, string) {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return p.typeOfIdent(t)
+
+	case *ast.SelectorExpr:
+		return p.typeOf(t.Sel)
+	}
+
+	// fallback
+	return "string", ""
+}
+
+func (p *ParamParser) typeOfIdent(ident *ast.Ident) (string, string) {
+	paramType := p.basicType(ident.Name)
+	if paramType != "" {
+		return paramType, ""
+	}
+
+	t := p.ctx.Package().TypesInfo.TypeOf(ident)
+	if t == nil {
+		// unknown
+		return "", ""
+	}
+
+	return p.parseTypeOfType(t)
+}
+
+// Swagger Parameter types:
+// Name		|	type	| 	format		|	Comments
+// integer	|	integer |	int32		|	signed 32 bits
+// long		|	integer |	int64		|	signed 64 bits
+// float	|	number 	|	float		|
+// double	|	number 	|	double		|
+// string	|	string 	|				|
+// byte		|	string 	|	byte		|	base64 encoded characters
+// binary	|	string 	|	binary		|	any sequence of octets
+// boolean	|	boolean |				|
+// date		|	string 	|	date		|	As defined by full-date - RFC3339
+// dateTime	|	string 	|	date-time	|	As defined by date-time - RFC3339
+// password	|	string 	|	password	|	Used to hint UIs the input needs to be obscured.
+func (p *ParamParser) basicType(name string) string {
+	switch name {
+	case "uint", "int", "uint8", "int8", "uint16", "int16",
+		"uint32", "int32", "uint64", "int64",
+		"byte", "rune":
+		return "integer"
+	case "float32", "float64":
+		return "number"
+	case "bool":
+		return "boolean"
+	case "string":
+		return "string"
+	}
+
+	return ""
+}
+
+// type:
+//		The value MUST be one of "string", "number", "integer", "boolean", "array" or "file".
+//		If type is "file", the consumes MUST be either "multipart/form-data", " application/x-www-form-urlencoded" or
+//		both and the parameter MUST be in "formData".
+func (p *ParamParser) param(name, paramType string, repeated bool) {
+	param := &spec.Parameter{}
+	param.Type = ""
+}
+
+func (p *ParamParser) parseTypeOfType(t types.Type) (string, string) {
+	switch t := t.(type) {
+	case *types.Named:
+		p.parseTypeOfType(t.Underlying())
+	case *types.Basic:
+		return p.parseTypeOfBasicType(t)
+	}
+
+	return "", ""
+}
+
+func (p *ParamParser) parseTypeOfBasicType(t *types.Basic) (string, string) {
+	switch t.Kind() {
+	case types.Bool:
+		return "boolean", ""
+	case types.Int,
+		types.Int8,
+		types.Int16,
+		types.Int32,
+		types.Int64,
+		types.Uint,
+		types.Uint8,
+		types.Uint16,
+		types.Uint32,
+		types.Uint64,
+		types.Uintptr:
+		return "integer", ""
+	case types.Float32,
+		types.Float64,
+		types.Complex64,
+		types.Complex128:
+		return "number", ""
+	case types.String:
+		return "string", ""
+	}
+
+	// unknown
+	return "", ""
+}

--- a/plugins/gin/config.go
+++ b/plugins/gin/config.go
@@ -1,6 +1,7 @@
 package gin
 
 type Config struct {
+	Request  []RequestRule  `yaml:"request"`
 	Response []ResponseRule `yaml:"response"`
 }
 
@@ -13,6 +14,17 @@ type ResponseRule struct {
 
 type ResponseReturn struct {
 	Status      string `yaml:"status"`
+	Data        string `yaml:"data"`
+	ContentType string `yaml:"contentType"`
+}
+
+type RequestRule struct {
+	Type   string         `yaml:"type"` // type name
+	Method string         `yaml:"method"`
+	Return *RequestReturn `yaml:"return"`
+}
+
+type RequestReturn struct {
 	Data        string `yaml:"data"`
 	ContentType string `yaml:"contentType"`
 }

--- a/plugins/gin/gin.go
+++ b/plugins/gin/gin.go
@@ -96,7 +96,13 @@ func (e *Plugin) assignStmt(ctx *analyzer.Context, node ast.Node) {
 
 			switch assign.Tok {
 			case token.ASSIGN:
-				ctx.Env.Assign(lhIdent.Name, rg)
+				env := ctx.Env.Resolve(lhIdent.Name)
+				if env == nil {
+					ctx.Env.Define(lhIdent.Name, rg)
+				} else {
+					env.Assign(lhIdent.Name, rg)
+				}
+
 			case token.DEFINE:
 				ctx.Env.Define(lhIdent.Name, rg)
 			}

--- a/plugins/gin/gin.go
+++ b/plugins/gin/gin.go
@@ -157,7 +157,7 @@ func (e *Plugin) parseAPI(ctx *analyzer.Context, callExpr *ast.CallExpr) (api *a
 	api.Spec.LoadFromFuncDecl(handlerFnDef.Decl)
 	NewHandlerParser(
 		ctx.NewEnv().WithPackage(handlerFnDef.Pkg()).WithFile(handlerFnDef.File()),
-		api.Spec,
+		api,
 		handlerFnDef.Decl,
 	).WithConfig(&e.config).Parse()
 	return

--- a/plugins/gin/gin.go
+++ b/plugins/gin/gin.go
@@ -18,6 +18,8 @@ var (
 
 const (
 	ginRouterGroupTypeName = "*github.com/gin-gonic/gin.RouterGroup"
+	ginIRouterTypeName     = "github.com/gin-gonic/gin.IRouter"
+	ginIRoutesTypeName     = "github.com/gin-gonic/gin.IRoutes"
 	routerGroupMethodName  = "Group"
 )
 
@@ -62,7 +64,10 @@ func (e *Plugin) assignStmt(ctx *analyzer.Context, node ast.Node) {
 	rh := assign.Rhs[0]
 	ctx.MatchCall(
 		rh,
-		analyzer.NewCallRule().WithRule(ginRouterGroupTypeName, routerGroupMethodName),
+		analyzer.NewCallRule().
+			WithRule(ginRouterGroupTypeName, routerGroupMethodName).
+			WithRule(ginIRouterTypeName, routerGroupMethodName).
+			WithRule(ginIRoutesTypeName, routerGroupMethodName),
 		func(callExpr *ast.CallExpr, typeName, fnName string) {
 			if len(callExpr.Args) <= 0 {
 				return
@@ -104,7 +109,9 @@ func (e *Plugin) assignStmt(ctx *analyzer.Context, node ast.Node) {
 func (e *Plugin) callExpr(ctx *analyzer.Context, callExpr *ast.CallExpr) {
 	ctx.MatchCall(
 		callExpr,
-		analyzer.NewCallRule().WithRule(ginRouterGroupTypeName, routeMethods...),
+		analyzer.NewCallRule().WithRule(ginRouterGroupTypeName, routeMethods...).
+			WithRule(ginIRouterTypeName, routeMethods...).
+			WithRule(ginIRoutesTypeName, routeMethods...),
 		func(call *ast.CallExpr, typeName, fnName string) {
 			api := e.parseAPI(ctx, callExpr)
 			if api == nil {

--- a/plugins/gin/testdata/server/config.gin.yaml
+++ b/plugins/gin/testdata/server/config.gin.yaml
@@ -7,6 +7,11 @@ depends:
   - encoding/json
 
 properties:
+  request:
+    - type: '*server/pkg/handler.CustomContext'
+      method: 'Bind'
+      return:
+        data: 'args[0]'
   response:
     - type: '*server/pkg/handler.CustomContext'
       method: 'JSONOK'

--- a/plugins/gin/testdata/server/pkg/handler/handler.go
+++ b/plugins/gin/testdata/server/pkg/handler/handler.go
@@ -14,6 +14,11 @@ func (c *CustomContext) JSONOK(data interface{}) {
 	c.JSON(http.StatusOK, data)
 }
 
+func (c *CustomContext) Bind(data interface{}) (err error) {
+	// ...
+	return
+}
+
 func Handler(handler func(c *CustomContext)) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		handler(&CustomContext{Context: c})

--- a/plugins/gin/testdata/server/pkg/shop/shop.go
+++ b/plugins/gin/testdata/server/pkg/shop/shop.go
@@ -53,8 +53,10 @@ func GoodsInfo(c *gin.Context) {
 }
 
 // GoodsDelete 删除商品
-func GoodsDelete(c *gin.Context) {
-
+// @consume multipart/form-data
+func GoodsDelete(c *handler.CustomContext) {
+	var request view.GoodsDeleteRequest
+	_ = c.Bind(&request)
 }
 
 func WrappedHandler(c *handler.CustomContext) {

--- a/plugins/gin/testdata/server/pkg/view/shop.go
+++ b/plugins/gin/testdata/server/pkg/view/shop.go
@@ -63,3 +63,7 @@ type GoodsInfoRes struct {
 type GoodsDownRes struct {
 	Status string `json:"status"`
 }
+
+type GoodsDeleteRequest struct {
+	FormDataField string `form:"formDataField"`
+}

--- a/plugins/gin/testdata/server/router.go
+++ b/plugins/gin/testdata/server/router.go
@@ -16,7 +16,7 @@ func ServeHttp() *gin.Engine {
 
 	// custom router group
 	cg := &CustomGroup{RouterGroup: &r.RouterGroup}
-	cg.DELETE("/api/goods/:guid", shop.GoodsDelete)
+	cg.DELETE("/api/goods/:guid", handler.Handler(shop.GoodsDelete))
 
 	// wrapped handler
 	cg.GET("/wrapped-handler", handler.Handler(shop.WrappedHandler))


### PR DESCRIPTION
## FIX: slice/array 类型 schema 解析

e.g.
```go
var res []Item
c.JSON(http.StatusOK, res)
```

## 支持配置自定义 Bind 函数

配置示例:
```yaml
properties:
  request:
    - type: '*server/pkg/handler.CustomContext'
      method: 'Bind'
      return:
        data: 'args[0]'
```

## 支持 c.Bind() 解析为 `form` 参数
```go
// @consume multipart/form-data
func XxxHandler(c *gin.Context) {
  var request view.XxxRequest
  c.Bind(&request)
}
```
如上所示，在 Handler 函数上方声明注解 `@consume multipart/form-data` 后，`c.Bind()` 会被解析为 `form` 参数。
 
当 `method` 为 `GET / HEAD ` 时，不声明注解会默认认为是 `form` 参数。

