### PR TITLE
代码生成模块 & TS 类型代码生成

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,9 @@ properties:
             data:
               type: 'args[0]' # 指定为第一个函数参数
         status: 200 # 指定为 200 状态码
+
+# 可选. 配置代码生成器
+generators:
+  - name: ts # 生成器名称. 暂时只支持 "ts" (用于生成 typescript 类型)
+    output: ./src/types # 输出文件的目录. 执行完成之后会在该目录下生成TS类型文件
 ```

--- a/formatter/README.md
+++ b/formatter/README.md
@@ -1,0 +1,4 @@
+# Formatter
+`formatter` 包用于实现对代码的生成及格式化。在本项目中用于前端的代码生成。
+
+本包的设计参考 `prettier` 实现，提供 `indent / join / line` 等工具方法。

--- a/formatter/doc.go
+++ b/formatter/doc.go
@@ -1,0 +1,34 @@
+package formatter
+
+type Doc interface {
+	docNode()
+}
+
+type DocContent string
+
+func (d DocContent) docNode() {}
+
+func NewDocContent(code string) *DocContent {
+	var res = DocContent(code)
+	return &res
+}
+
+type DocNodeType string
+
+const (
+	DocNodeIndent    DocNodeType = "string"
+	DocNodeLineBreak DocNodeType = "linebreak"
+)
+
+type DocNode struct {
+	Type  DocNodeType
+	Child Doc
+}
+
+func (d DocNode) docNode() {}
+
+type DocGroup struct {
+	Docs []Doc
+}
+
+func (d DocGroup) docNode() {}

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,0 +1,67 @@
+package formatter
+
+import "strings"
+
+type Options struct {
+	IndentWidth int
+}
+
+func Format(doc Doc, options *Options) string {
+	if options == nil {
+		options = &Options{IndentWidth: 4}
+	}
+	return NewFormatter(options).Format(doc)
+}
+
+type Formatter struct {
+	options     *Options
+	indent      int
+	atLineStart bool
+}
+
+func NewFormatter(options *Options) *Formatter {
+	return &Formatter{options: options, atLineStart: true}
+}
+
+func (f *Formatter) Format(doc Doc) string {
+	var code string
+
+	switch doc := doc.(type) {
+	case *DocContent:
+		if f.atLineStart {
+			code += f.makeIndent()
+			f.atLineStart = false
+		}
+		code += string(*doc)
+
+	case *DocGroup:
+		for _, doc := range doc.Docs {
+			code += f.Format(doc)
+		}
+
+	case *DocNode:
+		code = f.docNode(doc)
+	}
+
+	return code
+}
+
+func (f *Formatter) docNode(doc *DocNode) string {
+	switch doc.Type {
+	case DocNodeIndent:
+		f.indent += 1
+		defer func() { f.indent -= 1 }()
+		return f.Format(doc.Child)
+
+	case DocNodeLineBreak:
+		res := "\n"
+		f.atLineStart = true
+		return res
+	}
+
+	return ""
+}
+
+func (f *Formatter) makeIndent() string {
+	return strings.Repeat(" ", f.indent*f.options.IndentWidth)
+}

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -1,0 +1,72 @@
+package formatter
+
+import "testing"
+
+func TestFormat(t *testing.T) {
+	options := &Options{
+		IndentWidth: 4,
+	}
+
+	type args struct {
+		doc Doc
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "case1",
+			args: args{
+				doc: Group(
+					Content("export function hello() {"),
+					LineBreak(),
+					Indent(Join(
+						LineBreak(),
+						NewDocContent("console.log(\"hello, world\");"),
+						NewDocContent("return;"),
+					)),
+					LineBreak(),
+					Content("}"),
+				),
+			},
+			want: `export function hello() {
+    console.log("hello, world");
+    return;
+}`,
+		},
+		{
+			name: "nested-indent",
+			args: args{
+				doc: Group(
+					Content("export function hello() {"),
+					Indent(Group(
+						LineBreak(),
+						Join(
+							LineBreak(),
+							Content("{"),
+							Indent(NewDocContent("console.log(\"hello, world\");")),
+							Content("}"),
+							NewDocContent("return;"),
+						),
+					)),
+					LineBreak(),
+					Content("}"),
+				),
+			},
+			want: `export function hello() {
+    {
+        console.log("hello, world");
+    }
+    return;
+}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Format(tt.args.doc, options); got != tt.want {
+				t.Errorf("Format() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/formatter/utils.go
+++ b/formatter/utils.go
@@ -1,0 +1,36 @@
+package formatter
+
+func Indent(doc Doc) *DocNode {
+	return &DocNode{
+		Type:  DocNodeIndent,
+		Child: doc,
+	}
+}
+
+func LineBreak() *DocNode {
+	return &DocNode{
+		Type: DocNodeLineBreak,
+	}
+}
+
+func Join(sep Doc, docs ...Doc) *DocGroup {
+	res := &DocGroup{
+		Docs: make([]Doc, 0),
+	}
+	for i, item := range docs {
+		if i > 0 {
+			res.Docs = append(res.Docs, sep)
+		}
+		res.Docs = append(res.Docs, item)
+	}
+	return res
+}
+
+func Group(docs ...Doc) *DocGroup {
+	return &DocGroup{Docs: docs}
+}
+
+func Content(code string) *DocContent {
+	res := DocContent(code)
+	return &res
+}

--- a/generators/template.go
+++ b/generators/template.go
@@ -1,0 +1,21 @@
+package generators
+
+import (
+	"github.com/go-openapi/spec"
+)
+
+type Generator struct {
+	Type  string
+	Items []*Item
+}
+
+type Item struct {
+	FileName string
+	Print    func(schema *spec.Swagger) string
+}
+
+var Generators = make(map[string]*Generator)
+
+func RegisterGenerator(s *Generator) {
+	Generators[s.Type] = s
+}

--- a/generators/ts/ts.go
+++ b/generators/ts/ts.go
@@ -1,0 +1,129 @@
+package ts
+
+import (
+	_ "embed"
+
+	"github.com/go-openapi/spec"
+	f "github.com/gotomicro/ego-gen-api/formatter"
+	"github.com/gotomicro/ego-gen-api/generators"
+	"github.com/samber/lo"
+)
+
+var (
+	// Generator for typescript types
+	Generator = &generators.Generator{
+		Type: "ts",
+		Items: []*generators.Item{
+			Template,
+		},
+	}
+
+	Template = &generators.Item{
+		FileName: "types.ts",
+		Print: func(schema *spec.Swagger) string {
+			return f.Format(NewPrinter(schema).Print(), &f.Options{IndentWidth: 2})
+		},
+	}
+)
+
+func init() {
+	generators.RegisterGenerator(Generator)
+}
+
+type Printer struct {
+	schema *spec.Swagger
+}
+
+func NewPrinter(schema *spec.Swagger) *Printer {
+	return &Printer{schema: schema}
+}
+
+func (p *Printer) Print() f.Doc {
+	var docs []f.Doc
+	for _, definition := range p.schema.Definitions {
+		docs = append(docs, p.definition(definition))
+	}
+	return f.Join(f.Group(f.LineBreak(), f.LineBreak()), docs...)
+}
+
+func (p *Printer) definition(definition spec.Schema) f.Doc {
+	return f.Group(
+		f.Content("export type "+definition.Title+" = "),
+		p.printType(definition),
+	)
+}
+
+func (p *Printer) printType(definition spec.Schema) f.Doc {
+	var t = "object"
+	if len(definition.Type) > 0 {
+		t = definition.Type[0]
+	}
+
+	if !definition.Ref.GetPointer().IsEmpty() {
+		tokens := definition.Ref.GetPointer().DecodedTokens()
+		if len(tokens) != 2 || tokens[0] != "definitions" {
+			return f.Content("unknown")
+		}
+		return f.Content(p.schema.Definitions[tokens[1]].Title)
+	}
+
+	switch t {
+	case "object":
+		return p.printInterface(definition)
+	case "array":
+		schema := definition.Items.Schema
+		if schema == nil {
+			return f.Content("any[]")
+		}
+		return f.Group(
+			p.printType(*schema),
+			f.Content("[]"),
+		)
+	default:
+		return p.printBasicType(t)
+	}
+}
+
+func (p *Printer) printInterface(definition spec.Schema) f.Doc {
+	var fields []f.Doc
+	for name, schema := range definition.Properties {
+		required := lo.Contains(definition.Required, name)
+		fields = append(fields, p.property(name, schema, required))
+	}
+
+	return f.Group(
+		f.Content("{"),
+		f.LineBreak(),
+		f.Indent(f.Join(f.LineBreak(), fields...)),
+		f.LineBreak(),
+		f.Content("}"),
+	)
+}
+
+func (p *Printer) property(name string, schema spec.Schema, required bool) f.Doc {
+	var content = name
+	if !required {
+		content += "?"
+	}
+	content += ": "
+
+	return f.Group(
+		f.Content(content),
+		p.printType(schema),
+		f.Content(";"),
+	)
+}
+
+func (p *Printer) printBasicType(t string) f.Doc {
+	switch t {
+	case "string":
+		return f.Content("string")
+	case "number", "integer":
+		return f.Content("number")
+	case "boolean":
+		return f.Content("boolean")
+	case "file":
+		return f.Content("File")
+	}
+	return f.Content("unknown")
+}

--- a/plugins/gin/testdata/server/config.gin.yaml
+++ b/plugins/gin/testdata/server/config.gin.yaml
@@ -1,6 +1,6 @@
-output: docs
 plugin: gin
 dir: '.'
+output: docs # output directory of swagger.json
 
 depends:
   - github.com/gin-gonic/gin
@@ -21,10 +21,6 @@ properties:
         data:
           type: 'object'
           properties:
-            array:
-              type: 'array'
-              item:
-                type: 'number'
             code:
               type: 'number'
             msg:
@@ -32,3 +28,7 @@ properties:
             data:
               type: 'args[0]'
         status: 200
+
+generators:
+  - name: ts # generator name
+    output: ./src/types # output directory

--- a/plugins/gin/testdata/server/docs/swagger.json
+++ b/plugins/gin/testdata/server/docs/swagger.json
@@ -1,0 +1,306 @@
+{
+    "swagger": "2.0",
+    "info": {},
+    "paths": {
+        "/api/goods": {
+            "post": {
+                "description": " 创建商品",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Shop"
+                ],
+                "operationId": "POST./api/goods",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/server_pkg_view.GoodsCreateReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "创建成功",
+                        "schema": {
+                            "$ref": "#/definitions/server_pkg_view.GoodsCreateRes"
+                        }
+                    },
+                    "400": {
+                        "description": "参数无效",
+                        "schema": {
+                            "$ref": "#/definitions/server_pkg_view.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/goods/{guid}": {
+            "delete": {
+                "description": " 删除商品",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "operationId": "DELETE./api/goods/{guid}",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "name": "formDataField",
+                        "in": "form"
+                    }
+                ]
+            }
+        },
+        "/api/goods/{guid}/down": {
+            "post": {
+                "description": " 下架商品",
+                "produces": [
+                    "application/xml"
+                ],
+                "operationId": "POST./api/goods/{guid}/down",
+                "parameters": [
+                    {
+                        "description": "商品 GUID",
+                        "name": "guid",
+                        "in": "path"
+                    },
+                    {
+                        "description": "操作人 UID",
+                        "name": "operatorUid",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "日期范围",
+                        "name": "dateRange",
+                        "in": "formData"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/server_pkg_view.GoodsDownRes"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v2/goods/{guid}": {
+            "get": {
+                "description": " 商品详情",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "operationId": "GET./api/v2/goods/{guid}",
+                "parameters": [
+                    {
+                        "name": "guid",
+                        "in": "path"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/server_pkg_view.GoodsInfoRes"
+                        }
+                    }
+                }
+            }
+        },
+        "/wrapped-handler": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "operationId": "GET./wrapped-handler",
+                "parameters": [
+                    {
+                        "name": "hello",
+                        "in": "query"
+                    },
+                    {
+                        "name": "world",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "自定义响应函数",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "code": {
+                                    "type": "number"
+                                },
+                                "data": {
+                                    "$ref": "#/definitions/server_pkg_view.GoodsInfoRes"
+                                },
+                                "msg": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "github.com_gin-gonic_gin.Param": {
+            "id": "github.com_gin-gonic_gin.Param",
+            "title": "Param",
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            }
+        },
+        "github.com_gin-gonic_gin.Params": {
+            "id": "github.com_gin-gonic_gin.Params",
+            "type": "array",
+            "title": "Params",
+            "items": {
+                "$ref": "#/definitions/github.com_gin-gonic_gin.Param"
+            }
+        },
+        "server_pkg_view.Error": {
+            "id": "server_pkg_view.Error",
+            "title": "Error",
+            "properties": {
+                "code": {
+                    "type": "string"
+                }
+            }
+        },
+        "server_pkg_view.GoodsCreateReq": {
+            "id": "server_pkg_view.GoodsCreateReq",
+            "title": "GoodsCreateReq",
+            "required": [
+                "title",
+                "price"
+            ],
+            "properties": {
+                "cover": {
+                    "description": "封面图",
+                    "type": "string"
+                },
+                "images": {
+                    "description": "详情图",
+                    "type": "array",
+                    "nullable": true,
+                    "items": {
+                        "$ref": "#/definitions/server_pkg_view.Image"
+                    }
+                },
+                "price": {
+                    "description": "价格(分)",
+                    "type": "integer"
+                },
+                "subTitle": {
+                    "description": "商品描述",
+                    "type": "string",
+                    "nullable": true
+                },
+                "title": {
+                    "description": "商品标题",
+                    "type": "string"
+                }
+            }
+        },
+        "server_pkg_view.GoodsCreateRes": {
+            "id": "server_pkg_view.GoodsCreateRes",
+            "title": "GoodsCreateRes",
+            "properties": {
+                "Status": {
+                    "description": "测试引用第三方包",
+                    "$ref": "#/definitions/github.com_gin-gonic_gin.Params"
+                },
+                "guid": {
+                    "description": "商品 GUID",
+                    "type": "string"
+                },
+                "raw": {
+                    "description": "测试引用内置包类型",
+                    "type": "string",
+                    "format": "byte"
+                },
+                "selfRef": {
+                    "description": "测试循环引用",
+                    "$ref": "#/definitions/server_pkg_view.SelfRefType"
+                },
+                "stringAlias": {
+                    "description": "测试类型别名",
+                    "type": "string"
+                }
+            }
+        },
+        "server_pkg_view.GoodsDownRes": {
+            "id": "server_pkg_view.GoodsDownRes",
+            "title": "GoodsDownRes",
+            "properties": {
+                "Status": {
+                    "type": "string"
+                }
+            }
+        },
+        "server_pkg_view.GoodsInfoRes": {
+            "id": "server_pkg_view.GoodsInfoRes",
+            "title": "GoodsInfoRes",
+            "properties": {
+                "cover": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "integer"
+                },
+                "subTitle": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "server_pkg_view.Image": {
+            "id": "server_pkg_view.Image",
+            "title": "Image",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "url": {
+                    "description": "图片链接",
+                    "type": "string"
+                }
+            }
+        },
+        "server_pkg_view.SelfRefType": {
+            "id": "server_pkg_view.SelfRefType",
+            "title": "SelfRefType",
+            "properties": {
+                "data": {
+                    "type": "string"
+                },
+                "parent": {
+                    "$ref": "#/definitions/server_pkg_view.SelfRefType"
+                }
+            }
+        }
+    }
+}

--- a/plugins/gin/testdata/server/src/types/types.ts
+++ b/plugins/gin/testdata/server/src/types/types.ts
@@ -1,0 +1,46 @@
+export type Params = Param[]
+
+export type GoodsCreateRes = {
+  guid?: string;
+  selfRef?: SelfRefType;
+  Status?: Params;
+  stringAlias?: string;
+  raw?: string;
+}
+
+export type GoodsCreateReq = {
+  title: string;
+  subTitle?: string;
+  cover?: string;
+  price: number;
+  images?: Image[];
+}
+
+export type Error = {
+  code?: string;
+}
+
+export type SelfRefType = {
+  parent?: SelfRefType;
+  data?: string;
+}
+
+export type Param = {
+  Key?: string;
+  Value?: string;
+}
+
+export type GoodsDownRes = {
+  Status?: string;
+}
+
+export type GoodsInfoRes = {
+  price?: number;
+  title?: string;
+  subTitle?: string;
+  cover?: string;
+}
+
+export type Image = {
+  url: string;
+}


### PR DESCRIPTION
1. 实现了简易的类似于 `prettier` API 的代码生成模块 (formatter 目录)
2. 实现了 TS 类型代码生成器
  配置如下
  ```yaml
  # 可选. 配置代码生成器
  generators:
    - name: ts # 生成器名称. 暂时只支持 "ts" (用于生成 typescript 类型)
      output: ./src/types # 输出文件的目录. 执行完成之后会在该目录下生成TS类型文件
  ```